### PR TITLE
Use any(Predicate) instead of find(Predicate) in a collection

### DIFF
--- a/store/src/main/kotlin/com/cesarvaliente/kunidirectional/store/Dispatcher.kt
+++ b/store/src/main/kotlin/com/cesarvaliente/kunidirectional/store/Dispatcher.kt
@@ -47,8 +47,7 @@ abstract class Dispatcher<T> {
             subscriptions.forEach { it.onNext(data) }
 
     fun isSubscribed(subscriber: Subscriber<T>): Boolean {
-        val isSubscribed = subscriptions.find { it == subscriber }
-        return isSubscribed != null
+        return subscriptions.any { it == subscriber }
     }
 }
 


### PR DESCRIPTION
The any() extension function is better suited for the predicate previously used for filtering
https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/any.html

PS: Also subscriptions.contains(subscriber) would do the same job with slightly different implementation.